### PR TITLE
Python 3 compatible

### DIFF
--- a/ngSe/__init__.py
+++ b/ngSe/__init__.py
@@ -1,4 +1,4 @@
-from .browser import Browser
+from .browser import RemoteBrowser, ChromeBrowser, Browser
 from .by import By
 from .page import AppPage
 

--- a/ngSe/browser.py
+++ b/ngSe/browser.py
@@ -243,6 +243,8 @@ class RemoteBrowser(BrowserMixin, Remote):
 
         self.scenario = scenario
         self.pages = pages
+        self.app_host = app_host
+        self.app_port = app_port
 
         super(RemoteBrowser, self).__init__(
             desired_capabilities=DesiredCapabilities.CHROME,

--- a/ngSe/browser.py
+++ b/ngSe/browser.py
@@ -1,9 +1,8 @@
 from time import sleep
 from numbers import Number
-from types import NoneType
 from atexit import register as register_exit
 
-from urllib2 import URLError
+from urllib.error import URLError
 from selenium.webdriver import Chrome
 import selenium.common.exceptions as selenium_exceptions
 from selenium.webdriver.remote.webelement import WebElement
@@ -28,15 +27,15 @@ class Browser(Chrome):
     def __init__(self, scenario, download_directory=default_download_directory, app_host=None, app_port=None,
                  executable_path=None, pages=None):
         # Contract
-        must_be(download_directory, "download_directory", (NoneType, basestring))
-        must_be(app_host, "app_host", (NoneType, basestring))
-        must_be(app_port, "app_port", (NoneType, Number))
-        must_be(executable_path, "executable_path", (NoneType, basestring))
-        must_be(pages, "pages", (dict, NoneType))
+        must_be(download_directory, "download_directory", (type(None), str))
+        must_be(app_host, "app_host", (type(None), str))
+        must_be(app_port, "app_port", (type(None), Number))
+        must_be(executable_path, "executable_path", (type(None), str))
+        must_be(pages, "pages", (dict, type(None)))
         # TODO[TJ]: This should be implemented as part of the future contracts library
         if pages is not None:
-            for key, value in pages.iteritems():
-                must_be(key, "pages key", basestring)
+            for key, value in pages.items():
+                must_be(key, "pages key", str)
                 must_be(value, "pages value", AppPage)
         #
         self.scenario = scenario
@@ -72,7 +71,7 @@ class Browser(Chrome):
         This is really just a wrapper around passing the browser to a ByClause, allowing for much cleaner syntax.
         """
         # Contract
-        must_be(value, "value", basestring)
+        must_be(value, "value", str)
         must_be(by, "by", ByClause)
         #
 
@@ -82,7 +81,7 @@ class Browser(Chrome):
         """Wrapper to check for navigation issues, like 404's
         """
         # Contract
-        must_be(url, "url", basestring)
+        must_be(url, "url", str)
         #
         value = super(Browser, self).get(url)
         page_title = self.title
@@ -94,9 +93,9 @@ class Browser(Chrome):
         """Goes to a page in the app
         """
         # Contract
-        must_be(to, "to", (AppPage, basestring))
+        must_be(to, "to", (AppPage, str))
         #
-        if isinstance(to, basestring):
+        if isinstance(to, str):
             to = self.pages[to.lower()]
         url = "http://{host}:{port}/{page}".format(host=self.app_host, port=self.app_port, page=to.page)
         return_value = self.goto(url)
@@ -116,11 +115,11 @@ class Browser(Chrome):
         """Find, hover on, and click on the given element
         """
         # Contract
-        must_be(what, "element", basestring)
+        must_be(what, "element", str)
         must_be(by, "by", ByClause)
         must_be(hover_time, "hover_time", Number)
-        must_be(wait_for, "wait_for", (NoneType, basestring))
-        must_be(wait_for_by, "wait_for_by", (NoneType, ByClause))
+        must_be(wait_for, "wait_for", (type(None), str))
+        must_be(wait_for_by, "wait_for_by", (type(None), ByClause))
         #
         element = by.find(what, self)
         self.hover_on(element, hover_time)
@@ -174,11 +173,11 @@ class Browser(Chrome):
         """
         # Contract
         must_be(element, "element", WebElement)
-        must_be(text, "text", basestring)
+        must_be(text, "text", str)
         must_be(by, "by", ByClause)
         must_be(check, "check", bool)
-        must_be(check_against, "check_against", (NoneType, basestring))
-        must_be(check_attribute, "check_attribute", basestring)
+        must_be(check_against, "check_against", (type(None), str))
+        must_be(check_attribute, "check_attribute", str)
         must_be(empty, "empty", bool)
         #
         if empty:
@@ -194,12 +193,12 @@ class Browser(Chrome):
         """Finds and fills in an element with the given text.
         """
         # Contract
-        must_be(what, "element", basestring)
-        must_be(text, "text", basestring)
+        must_be(what, "element", str)
+        must_be(text, "text", str)
         must_be(by, "by", ByClause)
         must_be(check, "check", bool)
-        must_be(check_against, "check_against", (NoneType, basestring))
-        must_be(check_attribute, "check_attribute", basestring)
+        must_be(check_against, "check_against", (type(None), str))
+        must_be(check_attribute, "check_attribute", str)
         must_be(empty, "empty", bool)
         #
         element = by.find(what, self)

--- a/ngSe/by.py
+++ b/ngSe/by.py
@@ -23,14 +23,14 @@ class ByDict(dict):
 
     def __getitem__(self, item):
         # Performs generation of NegativeByClause's
-        if isinstance(item, basestring):
+        if isinstance(item, str):
             if item.startswith(self.negative_prefix):
                 return NegativeByClause(self[item[len(self.negative_prefix):]])
         return super(ByDict, self).__getitem__(item)
 
     def __setitem__(self, key, value):
         # Prevent inaccessible keys from getting in
-        if isinstance(key, basestring):
+        if isinstance(key, str):
             if key.startswith(self.negative_prefix):
                 raise ValueError("Keys in this dict cannot start with '{}'".format(self.negative_prefix))
         super(ByDict, self).__setitem__(key, value)
@@ -39,8 +39,8 @@ class ByDict(dict):
 By = ByDict()
 # Is this the best way to do this? Allow retrieving key: None = value: None (for simplifying step parsing)
 By[None] = None
-for key, value in selenium_by.__dict__.iteritems():
-    if not key.startswith('__') and isinstance(value, basestring):
+for key, value in selenium_by.__dict__.items():
+    if not key.startswith('__') and isinstance(value, str):
         By[key] = value
 
 
@@ -57,7 +57,7 @@ class ByClause(object):
 
     def __init__(self, by, f):
         # Contract
-        must_be(by, "by", basestring)
+        must_be(by, "by", str)
         if not hasattr(f, "__call__"):
             raise ValueError("f must be a callable")
         #
@@ -77,7 +77,7 @@ class ByClause(object):
         This is put here to be override-able, so you can, say, wait for the element to 'leave'
         """
         # Contract
-        must_be(what, "what", basestring)
+        must_be(what, "what", str)
         must_be(browser, "browser", Remote)
         #
         return self.find(what, browser)
@@ -86,7 +86,7 @@ class ByClause(object):
         """Finds the desired element (what) in the provided browser
         """
         # Contract
-        must_be(what, "what", basestring)
+        must_be(what, "what", str)
         must_be(browser, "browser", Remote)
         #
         what = self.convert(what)
@@ -113,7 +113,7 @@ class NegativeByClause(ByClause):
         """Waits for the desired element to 'leave'. Or tries to.
         """
         # Contract
-        must_be(what, "what", basestring)
+        must_be(what, "what", str)
         must_be(browser, "browser", Remote)
         #
         try:
@@ -126,7 +126,7 @@ class NegativeByClause(ByClause):
 
 def _inner_text_convert(value):
     # Contract
-    must_be(value, "value", basestring)
+    must_be(value, "value", str)
     #
     parts = value.split('\\')
     text = parts.pop()
@@ -138,7 +138,7 @@ def _inner_text_convert(value):
 
 def _table_path_convert(path):
     # Contract
-    must_be(path, "path", basestring)
+    must_be(path, "path", str)
     #
     parts = path.split('\\')
     if len(parts) < 3:
@@ -174,7 +174,7 @@ def _table_path_convert(path):
 
 def _list_path_convert(path):
     # Contract
-    must_be(path, "path", basestring)
+    must_be(path, "path", str)
     #
     parts = path.split('\\')
     if len(parts) < 2:
@@ -202,8 +202,8 @@ def _list_path_convert(path):
 By = ByDict()
 # Is this the best way to do this? Allow retrieving key: None = value: None (for simplifying step parsing)
 By[None] = None
-for key, value in selenium_by.__dict__.iteritems():
-    if not key.startswith('__') and isinstance(value, basestring):
+for key, value in selenium_by.__dict__.items():
+    if not key.startswith('__') and isinstance(value, str):
         By[key] = ByClause(value, lambda v: v)
 
 By.INNER_TEXT = ByClause(selenium_by.XPATH, _inner_text_convert)

--- a/ngSe/contract.py
+++ b/ngSe/contract.py
@@ -2,6 +2,7 @@
 # Here is where we put things that help fulfill this need. Optimally this
 # will eventually be its own package.
 
+
 # TODO[TJ]: This can, and should, be sliced off into its own library
 def must_be(what, name, types):
     if isinstance(what, types):

--- a/ngSe/page.py
+++ b/ngSe/page.py
@@ -1,5 +1,3 @@
-from types import NoneType
-
 from .by import ByClause, By
 from .contract import must_be
 
@@ -11,9 +9,9 @@ class AppPage(object):
 
     def __init__(self, page, wait_for=None, wait_for_by=By.ID):
         # Contract
-        if not isinstance(page, basestring) and not hasattr(page, "__call__"):
+        if not isinstance(page, str) and not hasattr(page, "__call__"):
             raise ValueError("page must be a string or callable")
-        must_be(wait_for, "wait_for", (NoneType, basestring))
+        must_be(wait_for, "wait_for", (type(None), str))
         must_be(wait_for_by, "wait_for_by", (ByClause))
         #
         self._page = page
@@ -22,6 +20,6 @@ class AppPage(object):
 
     @property
     def page(self):
-        if not isinstance(self._page, basestring) and hasattr(self._page, "__call__"):
+        if not isinstance(self._page, str) and hasattr(self._page, "__call__"):
             return self._page()
         return self._page


### PR DESCRIPTION
### Summary

Updated ngSe to be Python 3 compatible.
### How to Verify

Run selenium and/or ngSe in Python 3 and see if all actions still run correctly.
### Side Effects

I've heard there are slight differences between Python 2.x iteritems() and Python 3.x items(), but to be honest I had trouble figuring out if there was a better option than items().

fixes #8 
